### PR TITLE
Fix delimiter handling in parser

### DIFF
--- a/BatchRequests.js
+++ b/BatchRequests.js
@@ -156,9 +156,9 @@ function getBatchPath(name, version) {
       if (!check) {
         throw new Error("Valid response value is not returned.");
       }
-      const delimeter = check[0];
+      const delimiter = check[0];
       var regex, temp;
-      temp = d_.split(delimeter);
+      temp = d_.split(delimiter);
       regex = /{.+}/gs;
       if (!d_.match(regex)) {
         return d_;

--- a/BatchRequests.js
+++ b/BatchRequests.js
@@ -152,9 +152,14 @@ function getBatchPath(name, version) {
     };
 
     parser = function(d_) {
+      check = d_.match(/\r?\n--.*/);
+      if (!check) {
+        throw new Error("Valid response value is not returned.");
+      }
+      const delimeter = check[0];
       var regex, temp;
-      temp = d_.split("--batch");
-      regex = /{[\S\s]+}/g;
+      temp = d_.split(delimeter);
+      regex = /{.+}/gs;
       if (!d_.match(regex)) {
         return d_;
       }


### PR DESCRIPTION
If a response contained "--batch" (or if the server started using a delimiter other than "--batch"), the parser would get confused. This fixes that.

Note this does not fix the same issue with the binary parser nor a similar issue that could arise if a _request_ contains "--xxxxxxxxxx".
